### PR TITLE
Update WAMP_FEATURES constant with its attribute to prevent RN to crash at first socket connection.

### DIFF
--- a/js/lib/session.js
+++ b/js/lib/session.js
@@ -9,8 +9,7 @@ Date.now = Date.now || function () {
 
 // WAMP "Advanced Profile" support in AutobahnJS per role
 // ignore now.
-const WAMP_FEATURES = {};
-
+const WAMP_FEATURES = {caller: {features:[]},callee: {features:[]}, publisher: {features:[]},subscriber: {features:[]} };
 
 // replace when/function/call
 //


### PR DESCRIPTION
Update WAMP_FEATURES constant with its attribute to prevent RN to crash at first socket connection.